### PR TITLE
feat(prompt): add write-commit prompt template

### DIFF
--- a/public/objects/write-commit.yaml
+++ b/public/objects/write-commit.yaml
@@ -1,0 +1,17 @@
+title: Write commit message
+description: Ask the AI to write a commit message following a template, diffing the git staged changes
+type: Prompt
+
+# External Resources
+link: https://app.warp.dev/drive/prompt/write-commit-muFHXyQAl82A8Zmz3nFMcE
+
+# Metadata
+author: "albertodeago"
+date_added: 2024-04-04
+
+# Classification
+tags:
+  - git
+  - commit
+  - quality
+  - code-review


### PR DESCRIPTION
Add a prompt to generate commit-messages.

Example of what's being generate specifically for this commit:
```
Before this:
No existing template for generating standardized commit messages was available in the project, making it harder to maintain consistent commit message quality.

After this:
Added a new YAML template for generating commit messages that follows conventional commits format. The template includes metadata, classification tags, and helps users write better commit messages with AI assistance.
```