### PR TITLE
Fix contradictory tag comment in duplicate-me.yaml template

### DIFF
--- a/public/objects/duplicate-me.yaml
+++ b/public/objects/duplicate-me.yaml
@@ -12,6 +12,6 @@ date_added: YYYY-MM-DD # Current date in YYYY-MM-DD format
 
 # Classification -- these should all be in lowercase for consistency
 tags:
-  - tag1 # Add relevant tags that describe your contribution. Make them all caps and just one word.
+  - tag1 # Add relevant tags that describe your contribution. Use lowercase; multi-word tags can be hyphenated (e.g., code-analysis).
   - tag2 # Common tags include: devops, github, automation, coding, etc.
   - tag3 # You can add as many tags as needed


### PR DESCRIPTION
## Summary

The contribution template at `public/objects/duplicate-me.yaml` carries contradictory guidance for tag formatting:

- The section header reads: `# Classification -- these should all be in lowercase for consistency`
- The inline comment on `tag1` reads: `Make them all caps and just one word.`

## Why this matters

I checked every existing entry under `public/objects/`:

- 60 unique tags across 35 entries are **all lowercase** — zero uppercase tags.
- 7 are **hyphenated multi-word** tags (`code-analysis`, `code-review`, `development-tools`, `package-manager`, `pull-request`, `text-editor`, `version-control`).

So the inline comment is wrong on both axes (case and word count), and the header comment matches reality.

The contradiction has actually confused at least one past contributor: `public/objects/pack-bat-cli.yaml` shipped with the template's stray explanatory comments still attached to its tag list — see the trailing `# Add relevant tags…`, `# Common tags include…`, `# You can add as many tags as needed` comments alongside its real tags.

## Change

Replace the misleading inline comment with one that matches the header and the existing data:

```diff
-  - tag1 # Add relevant tags that describe your contribution. Make them all caps and just one word.
+  - tag1 # Add relevant tags that describe your contribution. Use lowercase; multi-word tags can be hyphenated (e.g., code-analysis).
```

Single-line, docs-only, no behavior change.
