### PR TITLE
Redirect dothings.warp.dev to warp.dev

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,24 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // The "Do Things with Warp" site is being sunset. All traffic to this
+  // deployment (dothings.warp.dev and any preview alias) is permanently
+  // redirected to warp.dev. Two rules so the root path resolves cleanly
+  // and every other path falls through to the same destination.
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "https://warp.dev/",
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        destination: "https://warp.dev/",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
Adds a Next.js `redirects()` config that permanently (308) redirects every path served by this deployment to `https://warp.dev/`. The site is being sunset and we want all inbound traffic to land on the main marketing site instead.

Two rules:
- `/` → `https://warp.dev/`
- `/:path*` → `https://warp.dev/` (catches every other path)

## Why
Pairs with the upstream change in `warp-marketing-3` (PR #339) that removes on-site entry points to `dothings.warp.dev`:
- the footer `Do Things with Warp` link is dropped, and
- the `/dothings` and `/do-things` short links on `warp.dev` now point to `/` instead of `https://dothings.warp.dev/`.

After this PR ships, anyone who follows an old bookmark, cached search result, or external link to `https://dothings.warp.dev/*` lands on `https://warp.dev/`.

## Notes for reviewers
- I considered using a Vercel domain-level redirect on the `dothings.warp.dev` alias (instant, no deploy required). Vercel rejected that approach because the redirect target (`warp.dev`) is attached to a different Vercel project. A code-level Next.js redirect works for any external destination, so this is the right path.
- `do-things.warp.dev` (with the dash) does not currently have DNS or a Vercel domain attached, so nothing serves it today and no redirect is needed there. If we ever attach that hostname to this project, it'll inherit the same redirect automatically.
- Build verified locally: `npm run build` succeeds and emits the redirect rules.

_This PR was generated with [Oz](https://warp.dev/oz)._
